### PR TITLE
feat: initial Streamlit skeleton with mortgage util

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+.env
+venv/
+.DS_Store

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Contributing to DwellWell
+
+- Use **Python 3.11**.
+- Follow **PEP 8** style guidelines. Run `ruff --fix .` before committing.
+- Run the test suite with `pytest -q`.
+- Never commit secrets or credentials. Use environment variables or `.env` files excluded via `.gitignore`.
+- Monetary values should be handled in **CAD cents** to avoid floating point issues.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# housing
+# DwellWell
+
+DwellWell is a Streamlit app for evaluating the purchase of a two-bedroom, two-bathroom condo in downtown Vancouver. It calculates key financial metrics using user inputs and will eventually include Monte Carlo simulations to explore different market scenarios.
+
+## Running the app
+
+1. Install dependencies with `pip install -r requirements.txt`.
+2. Execute `streamlit run app.py`.
+3. Run `ruff --fix .` and `pytest -q` before committing changes.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,44 @@
+import altair as alt
+import pandas as pd
+import streamlit as st
+
+st.set_page_config(page_title="DwellWell", layout="wide")
+
+st.sidebar.header("Input Parameters")
+
+purchase_price = st.sidebar.number_input(
+    "Purchase Price (CAD)", min_value=0, step=1_000
+)
+down_payment_pct = st.sidebar.number_input(
+    "Down Payment (%)", min_value=0.0, max_value=100.0, value=20.0
+)
+interest_rate = st.sidebar.number_input("Interest Rate (%)", min_value=0.0, value=5.0)
+strata_fee = st.sidebar.number_input("Monthly Strata Fee (CAD)", min_value=0, step=10)
+property_tax = st.sidebar.number_input(
+    "Annual Property Tax (CAD)", min_value=0, step=100
+)
+expected_rent = st.sidebar.number_input(
+    "Expected Monthly Rent (CAD)", min_value=0, step=10
+)
+vacancy_pct = st.sidebar.number_input(
+    "Vacancy Rate (%)", min_value=0.0, max_value=100.0, value=2.0
+)
+scenario = st.sidebar.selectbox("Scenario", ["Live-in", "Rent-out"])
+
+st.title("DwellWell")
+
+st.header("Key Metrics")
+col1, col2, col3 = st.columns(3)
+col1.metric("Monthly Mortgage", "0")
+col2.metric("Net Cash Flow", "0")
+col3.metric("ROI", "0")
+
+# TODO: Plug in Monte Carlo simulation results here
+
+st.header("Projections")
+empty_df = pd.DataFrame({"x": [], "y": []})
+line_chart = alt.Chart(empty_df).mark_line().encode(x="x", y="y")
+bar_chart = alt.Chart(empty_df).mark_bar().encode(x="x", y="y")
+
+st.altair_chart(line_chart, use_container_width=True)
+st.altair_chart(bar_chart, use_container_width=True)

--- a/models.py
+++ b/models.py
@@ -1,0 +1,36 @@
+"""Financial models for DwellWell."""
+
+from __future__ import annotations
+
+
+def mortgage_payment(principal: int, annual_rate: float, amort_years: int = 25) -> int:
+    """Return the monthly mortgage payment in CAD cents.
+
+    Args:
+        principal: Loan principal in CAD cents.
+        annual_rate: Annual interest rate as a percentage (e.g., 5 for 5%).
+        amort_years: Amortization period in years. Defaults to 25.
+
+    Returns:
+        Monthly payment in CAD cents.
+    """
+    months = amort_years * 12
+    monthly_rate = (annual_rate / 100) / 12
+    if monthly_rate == 0:
+        payment = principal / months
+    else:
+        payment = (
+            principal
+            * monthly_rate
+            * (1 + monthly_rate) ** months
+            / ((1 + monthly_rate) ** months - 1)
+        )
+    return int(round(payment))
+
+
+def cash_flow(*args, **kwargs):
+    """Calculate monthly cash flow.
+
+    TODO: implement in later iterations.
+    """
+    pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+streamlit
+pandas
+numpy
+altair
+pytest

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from models import mortgage_payment
+
+
+def test_mortgage_payment_known_value():
+    principal = 400_000 * 100  # 400k CAD in cents
+    payment = mortgage_payment(principal, annual_rate=5.0, amort_years=25)
+    assert payment == 233_836


### PR DESCRIPTION
## Summary
- set up Streamlit skeleton app
- add mortgage calculator utilities
- provide tests for mortgage payments
- document contribution guidelines and project overview
- add requirements and gitignore

## Testing
- `ruff check --fix .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687401de7da48332880eab788dccfef9