### PR TITLE
Dynamic listing CSV upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,6 @@ DwellWell is a Streamlit app for evaluating the purchase of a two-bedroom, two-b
 1. Install dependencies with `pip install -r requirements.txt`.
 2. Execute `streamlit run app.py`.
 3. Run `ruff --fix .` and `pytest -q` before committing changes.
+
+## Usage
+- You can upload a CSV of listings to pre-fill deal variables.

--- a/app.py
+++ b/app.py
@@ -1,24 +1,60 @@
 import altair as alt
+import math
 import pandas as pd
 import streamlit as st
 
 st.set_page_config(page_title="DwellWell", layout="wide")
 
+uploaded_file = st.file_uploader("Upload Listings CSV", type="csv")
+listings_df = None
+selected_row: dict[str, object] = {}
+if uploaded_file is not None:
+    listings_df = pd.read_csv(uploaded_file)
+    st.dataframe(listings_df)
+    option_labels = listings_df.apply(
+        lambda r: f"{r.get('address', '')} – ${r.get('list_price', '')}",
+        axis=1,
+    ).tolist()
+    chosen = st.selectbox("Choose a listing", option_labels)
+    idx = option_labels.index(chosen)
+    selected_row = listings_df.iloc[idx].to_dict()
+
+
+def default_for(key: str, fallback: float | int) -> float | int:
+    val = selected_row.get(key)
+    if val is None or (isinstance(val, float) and math.isnan(val)):
+        return fallback
+    return val
+
 st.sidebar.header("Input Parameters")
 
 purchase_price = st.sidebar.number_input(
-    "Purchase Price (CAD)", min_value=0, step=1_000
+    "Purchase Price (CAD)",
+    min_value=0,
+    step=1_000,
+    value=int(default_for("list_price", 0)),
 )
 down_payment_pct = st.sidebar.number_input(
     "Down Payment (%)", min_value=0.0, max_value=100.0, value=20.0
 )
 interest_rate = st.sidebar.number_input("Interest Rate (%)", min_value=0.0, value=5.0)
-strata_fee = st.sidebar.number_input("Monthly Strata Fee (CAD)", min_value=0, step=10)
+strata_fee = st.sidebar.number_input(
+    "Monthly Strata Fee (CAD)",
+    min_value=0,
+    step=10,
+    value=int(default_for("strata_fee", 0)),
+)
 property_tax = st.sidebar.number_input(
-    "Annual Property Tax (CAD)", min_value=0, step=100
+    "Annual Property Tax (CAD)",
+    min_value=0,
+    step=100,
+    value=int(default_for("property_tax", 0)),
 )
 expected_rent = st.sidebar.number_input(
-    "Expected Monthly Rent (CAD)", min_value=0, step=10
+    "Expected Monthly Rent (CAD)",
+    min_value=0,
+    step=10,
+    value=int(default_for("expected_rent", 0)),
 )
 vacancy_pct = st.sidebar.number_input(
     "Vacancy Rate (%)", min_value=0.0, max_value=100.0, value=2.0

--- a/tests/test_csv_loader.py
+++ b/tests/test_csv_loader.py
@@ -1,0 +1,20 @@
+from io import StringIO
+import pandas as pd
+
+
+def test_csv_loader_types():
+    csv = "address,list_price,bedrooms,bathrooms\n123 A St,500000,2,2"
+    df = pd.read_csv(StringIO(csv))
+    assert df['list_price'].dtype.kind in "iu"
+    assert df['bedrooms'].dtype.kind in "iuf"
+    assert df['bathrooms'].dtype.kind in "iuf"
+
+
+def test_csv_loader_missing_optional_columns():
+    csv = "address,list_price\n123 A St,500000"
+    try:
+        df = pd.read_csv(StringIO(csv))
+    except Exception as exc:  # pragma: no cover - should not happen
+        raise AssertionError(f"Reading CSV raised {exc}")
+    assert 'address' in df.columns
+    assert df['list_price'].iloc[0] == 500000


### PR DESCRIPTION
## Summary
- add file uploader and listing selector to populate sidebar defaults
- document CSV upload option
- test CSV loading with pandas

## Testing
- `ruff check --fix .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874066ec1688332bd0ae39c469a1a57